### PR TITLE
Simplify status code detection

### DIFF
--- a/CoreSolutions.Common.Web/Middlewares/ErrorLoggingMiddleware.cs
+++ b/CoreSolutions.Common.Web/Middlewares/ErrorLoggingMiddleware.cs
@@ -57,18 +57,13 @@ namespace CoreSolutions.Common.Web.Middlewares
         /// </returns>
         private static async Task HandleExceptionAsync(HttpContext context, Exception exception)
         {
-            var code = StatusCodes.Status500InternalServerError;
-
-            if (exception is ArgumentException || exception is ArgumentNullException)
-            {
-                code = StatusCodes.Status400BadRequest;
-            }
-
             var obj = new { errorMessage = exception.Message };
             var result = JsonConvert.SerializeObject(obj);
 
             context.Response.ContentType = Constants.ApplicationJson;
-            context.Response.StatusCode = code;
+            context.Response.StatusCode = exception is ArgumentException
+                ? StatusCodes.Status400BadRequest
+                : StatusCodes.Status500InternalServerError;
 
             await context.Response.WriteAsync(result);
         }


### PR DESCRIPTION
Привет! Заметил, что `exception is ArgumentNullException` всегда будет `false`, т.к. `ArgumentNullException` происходит от `ArgumentException`. Думаю, лучше убрать, тогда и определение статус кода сократится до тернарного выражения.